### PR TITLE
Oro 6.0.x compatibility added

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
         "Integration"
     ],
     "require": {
-        "php": ">=8.2",
-        "oro/platform": "5.1.*",
-        "oro/platform-serialised-fields": "5.1.*",
-        "oro/commerce": "5.1.*",
+        "php": "~8.3.0",
+        "oro/platform": "6.0.*",
+        "oro/platform-serialised-fields": "6.0.x-dev",
+        "oro/commerce": "6.0.*",
         "ext-simplexml": "*"
     },
     "version": "1.0.0",

--- a/src/Builder/ShippingPackagesBuilder.php
+++ b/src/Builder/ShippingPackagesBuilder.php
@@ -71,7 +71,7 @@ class ShippingPackagesBuilder
      *
      * @throws PackageException
      */
-    public function addLineItem(ShippingLineItemInterface $lineItem): bool
+    public function addLineItem(\Oro\Bundle\ShippingBundle\Context\ShippingLineItem $lineItem): bool
     {
         if (!$lineItem->getWeight()) {
             $this->badItemException($lineItem, 'Unknown weight.');
@@ -140,7 +140,7 @@ class ShippingPackagesBuilder
      *
      * @throws PackageException
      */
-    private function badItemException(ShippingLineItemInterface $lineItem, ?string $message = ''): void
+    private function badItemException(\Oro\Bundle\ShippingBundle\Context\ShippingLineItem $lineItem, ?string $message = ''): void
     {
         throw new PackageException(
             sprintf(

--- a/src/Command/StationExportCommand.php
+++ b/src/Command/StationExportCommand.php
@@ -34,10 +34,10 @@ use Symfony\Component\Serializer\Exception\ExceptionInterface;
  * @license   https://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * @link      https://www.dnd.fr/
  */
+#[\Symfony\Component\Console\Attribute\AsCommand('dnd:dpd:station-export:test', 'Helps debugging station export by outputing the export data for a given order.')]
 class StationExportCommand extends Command
 {
     protected ?ParameterBag $settings = null;
-    protected static $defaultName = 'dnd:dpd:station-export:test';
     protected StationExportProcessor $stationExportProcessor;
     /**
      * @var DpdShippingPackageOptionsInterface[]|null $packages
@@ -58,7 +58,7 @@ class StationExportCommand extends Command
     /** @noinspection PhpMissingParentCallCommonInspection */
     protected function configure(): void
     {
-        $this->setDescription('Helps debugging station export by outputing the export data for a given order.')
+        $this
             ->addArgument(
                 'id',
                 InputArgument::REQUIRED,
@@ -90,7 +90,7 @@ HELP
         if (!$order instanceof Order) {
             $output->writeln('Could not find requested order');
 
-            return 0;
+            return \Symfony\Component\Console\Command\Command::SUCCESS;
         }
         $shippingService = $this->shippingServiceProvider->getServiceForMethodTypeIdentifier(
             $order->getShippingMethodType()
@@ -106,7 +106,7 @@ HELP
             $output->writeln('Something wrong happened with the order.');
             $output->write($e->getMessage());
 
-            return 0;
+            return \Symfony\Component\Console\Command\Command::SUCCESS;
         }
 
         $output->writeln(
@@ -120,7 +120,7 @@ HELP
         $table->setHeaders(['code', 'position', 'length', 'value'])->setRows($data);
         $table->render();
 
-        return 0;
+        return \Symfony\Component\Console\Command\Command::SUCCESS;
     }
 
     /**

--- a/src/Controller/Frontend/RelayController.php
+++ b/src/Controller/Frontend/RelayController.php
@@ -9,7 +9,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 
 /**
@@ -17,15 +17,14 @@ use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
  * @copyright 2004-present Agence Dn'D
  * @license   https://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  * @link      https://www.dnd.fr/
- * @Route("/dpd_france")
  */
+#[\Symfony\Component\Routing\Attribute\Route(path: '/dpd_france')]
 class RelayController extends AbstractController
 {
     /**
      * Returns a list of nearby pudos
-     *
-     * @Route("/relays", name="dpd_france_relay_list", methods={"GET", "POST"})
      */
+    #[\Symfony\Component\Routing\Attribute\Route(path: '/relays', name: 'dpd_france_relay_list', methods: ['GET', 'POST'])]
     public function listAction(Request $request, PudoProvider $pudoProvider): JsonResponse
     {
         $checkoutId = $request->get('checkoutId');
@@ -59,9 +58,8 @@ class RelayController extends AbstractController
 
     /**
      * Returns all them details about a pudo
-     *
-     * @Route("/relay/{pudoId}", name="dpd_france_relay_details", methods={"GET"})
      */
+    #[\Symfony\Component\Routing\Attribute\Route(path: '/relay/{pudoId}', name: 'dpd_france_relay_details', methods: ['GET'])]
     public function detailsAction(string $pudoId, PudoProvider $pudoProvider): JsonResponse
     {
         try {

--- a/src/Factory/PackageFactory.php
+++ b/src/Factory/PackageFactory.php
@@ -30,7 +30,7 @@ class PackageFactory
      * @throws PackageException
      */
     public function create(
-        ShippingLineItemCollectionInterface $lineItemCollection,
+        \Doctrine\Common\Collections\Collection $lineItemCollection,
         ShippingService $shippingService,
         int $websiteId
     ): array {


### PR DESCRIPTION
This PR can be used as a starting point for the extension upgrade.
Most of the changes were done automatically with the upgrade-toolkit tool.

Here is a short list of done changes:
- Updated requirements to oro/platform 6.0.*
- Updated requirements to oro/platform-serialised-fields 6.0.*
- Updated requirements to oro/commerce 6.0.*
- oro/upgrade-toolkit automatic migrations applied
